### PR TITLE
Update docker-compose.yml

### DIFF
--- a/jira/docker-compose.yml
+++ b/jira/docker-compose.yml
@@ -41,4 +41,3 @@ networks:
   atlassiannet:
     external:
       name: network-atlassian
-	  


### PR DESCRIPTION
removed extra line number 44, it was causing the issue during the deployment.

ERROR: yaml.scanner.ScannerError: while scanning for the next token
found character '\t' that cannot start any token
  in "./docker-compose.yml", line 44, column 1
